### PR TITLE
fix: 低版本无法安装matplotlib依赖的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 oss2
 aliyun-python-sdk-core==2.13.3
-matplotlib==3.3.4
+matplotlib==3.5.2
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as f:
 requires = [
     "oss2",
     "aliyun-python-sdk-core==2.13.3",
-    "matplotlib==3.3.4"
+    "matplotlib==3.5.2"
 ]
 
 setup_args = {


### PR DESCRIPTION
可以适当提高依赖的matplotlib版本，而不会出现问题
目前的低版本在python3.10中无法被安装